### PR TITLE
Sites Separation

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -100,24 +100,10 @@
 
 
 
-.degree-type {
-    font-size: 14px;
-}
 
-.links-container div {
-    margin-left: 3%;
-}
+
+
 
 .dates {
     float: right;
-}
-
-.linkedin a {
-    font-size: x-small;
-}
-
-div a {
-    text-decoration: none;
-    font-size: small;
-    color: black;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -186,12 +186,8 @@
         </div>
 
         <div class="right-side-child-container">
-            <div class="links-container">
-                <h4>SITES</h4>
-                <hr>
-                <div class="linkedin"><a href="https://www.linkedin.com/in/zachary-miller-82179483/">https://www.linkedin.com/in/zachary-miller-82179483/</a></div>
-                <div class="github"><a href="https://github.com/zacharycmiller">https://github.com/zacharycmiller</a></div>
-            </div>
+            <app-sites></app-sites>
+            
         </div>
     </div>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { AboutMeComponent } from './components/about-me/about-me.component';
 import { ImageComponent } from './components/image/image.component';
 import { ContactComponent } from './components/contact/contact.component';
 import { EducationComponent } from './components/education/education.component';
+import { SitesComponent } from './components/sites/sites.component';
 
 @NgModule({
   declarations: [
@@ -18,7 +19,8 @@ import { EducationComponent } from './components/education/education.component';
     AboutMeComponent,
     ImageComponent,
     ContactComponent,
-    EducationComponent
+    EducationComponent,
+    SitesComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/education/education.component.css
+++ b/src/app/components/education/education.component.css
@@ -9,3 +9,7 @@
 .education-container hr {
     opacity: 25%;
 }
+
+.education-degree-type {
+    font-size: 14px;
+}

--- a/src/app/components/sites/sites.component.css
+++ b/src/app/components/sites/sites.component.css
@@ -1,0 +1,21 @@
+.sites-container div {
+    margin-left: 3%;
+}
+
+.sites-container h4 {
+    margin: 1%;
+}
+
+.sites-container hr {
+    opacity: 25%;
+}
+
+.linkedin a {
+    font-size: x-small;
+}
+
+div a {
+    text-decoration: none;
+    font-size: small;
+    color: black;
+}

--- a/src/app/components/sites/sites.component.html
+++ b/src/app/components/sites/sites.component.html
@@ -1,0 +1,16 @@
+<div class="sites-container">
+    <h4>SITES</h4>
+    <hr>
+
+    <div class="linkedin">
+        <a href={{sites.linkedin}}>
+            {{sites.linkedin}}
+        </a>
+    </div>
+
+    <div class="github">
+        <a href={{sites.github}}>
+            {{sites.github}}
+        </a>
+    </div>
+</div>

--- a/src/app/components/sites/sites.component.spec.ts
+++ b/src/app/components/sites/sites.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SitesComponent } from './sites.component';
+
+describe('SitesComponent', () => {
+  let component: SitesComponent;
+  let fixture: ComponentFixture<SitesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SitesComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SitesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/sites/sites.component.ts
+++ b/src/app/components/sites/sites.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { Sites } from 'src/app/models/sites-model';
+import { SitesService } from 'src/app/services/sites.service';
+
+@Component({
+  selector: 'app-sites',
+  templateUrl: './sites.component.html',
+  styleUrls: ['./sites.component.css']
+})
+export class SitesComponent {
+  sites!: Sites;
+
+  ngOnInit(): void {
+    this.getSites();
+  }
+  
+  constructor(
+    private siteService: SitesService
+  ) {}
+
+  getSites(): void {
+    this.sites = this.siteService.getSites();
+  }
+}

--- a/src/app/data/sites.ts
+++ b/src/app/data/sites.ts
@@ -1,0 +1,7 @@
+import { Sites } from "../models/sites-model";
+
+export const SITES: Sites = {
+    id: 0,
+    linkedin: "https://www.linkedin.com/in/zachary-miller-82179483/",
+    github: "https://github.com/zacharycmiller"
+}

--- a/src/app/models/sites-model.ts
+++ b/src/app/models/sites-model.ts
@@ -1,0 +1,5 @@
+export interface Sites {
+    id: number;
+    linkedin: string;
+    github: string;
+}

--- a/src/app/services/sites.service.spec.ts
+++ b/src/app/services/sites.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SitesService } from './sites.service';
+
+describe('SitesService', () => {
+  let service: SitesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SitesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/sites.service.ts
+++ b/src/app/services/sites.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+
+import { Sites } from '../models/sites-model';
+import { SITES } from '../data/sites';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SitesService {
+
+  constructor() { }
+
+  getSites(): Sites {
+    return SITES;
+  }
+}


### PR DESCRIPTION
Previously missed items:
Transferred styling for .degree-type from main component to education component

Created sites model:
Properties: id (number), linkedin (string), github (string)

Created sites mock data:
Utilized hard-coded information from main component html as mock data

Created sites service:
imported Sites model and SITES mock data
Created getSites function which returns a Sites object with SITES mock data

Created sites component:
TS:
Added Sites property sites
Injected SitesService into constructor
Created getSites function which assigns the result of calling this.sitesService.getSites to the sites property
Added a call to getSites in ngOnInit

HTML:
Added app-sites tag to main component html
Transferred hard-coded html to sites component
Modified the hard-coded data to string interpolations for the associated sites object properties both for href and a tag text

CSS:
Transferred appropriate stylings to sites component
Modified class names as necessary

Reviewed changes by reviewed Print preview of current page with previously printed version


