### PR TITLE
Separated previous work experience

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -47,9 +47,6 @@
     margin-top: 10px;
 }
 
-.previous-it-experience {
-    margin-top: 4%;
-}
 
 
 .right-side-container {
@@ -103,7 +100,3 @@
 
 
 
-
-.dates {
-    float: right;
-}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -57,65 +57,8 @@
                 </div>
             </div>
 
-
-            <div class="previous-it-experience"><h4>Previous Experience:</h4>
-                <div class="work-experience-child-container">
-
-                    <div class="job-title-and-dates">
-                        <span class="job-title">System Administrator</span><span class="dates">August 2017 - July 2020</span>
-                    </div>
-
-                    <div class="job-title-and-dates">
-                        <span class="job-title">InFlyt Entertainment (Thales Avionics)</span><span class="dates">Orlando, FL</span>
-                    </div>
-
-                    <!--
-                    <div class="other-work-child-container">
-                        <div class="responsibilities-container">
-                            Responsibilities: <br>
-                            Administration of 40 remote servers located at airports around the world, monitoring and troubleshooting of 200+ servers across a multi-domain, global, mostly virtualized ground infrastructure, real-time monitoring of 100+ aircraft comprised of multiple airlines each with unique SLAs. Initial analysis of issues on in- flight systems comprised of high end; proprietary systems for providing movies, live television, and internet. Assisting in development of tools and documentation for the troubleshooting, maintenance, and administration of all aspects of the job including spreadsheets, basic html, basic Powershell scripting, KB articles (end-user, technical, and administrative), and training.
-                        </div>
-                        <div class="technologies-container">
-                            Tools / Technologies: <br>
-                            AWS, Windows Server, VMWare, Jira, Salesforce, NetApp, HP, PowerShell, PRTG, Mutliple proprietary tools
-                        </div>
-                    </div>
-                    -->
-                </div>
-
-                <div class="work-experience-child-container">
-                    
-                    <div class="job-title-and-dates">
-                        <span class="job-title">Technical Support Engineer II</span><span class="dates">August 2015 - August 2017</span>
-                    </div>
-
-                    <div class="job-title-and-dates">
-                        <span class="job-title">Convergys: (NetApp Account)</span><span class="dates">Lake Mary, FL</span>
-                    </div>   
-
-                    <!--
-                    <div class="other-work-child-container">
-                        <div class="responsibilities-container">
-                            Responsibilities: <br>
-                            One of four members of the CORE escalations vertical. Responsibilities include diagnosis, reproduction, resolution, and documentation of both software and hardware issues such as NFS, UNIX remote file sharing protocol; SMB, Windows NT remote file sharing protocol; client’s dedicated multi-protocol network file servers with innovative architecture, optimized file system including Write Anywhere File Layout (WAFL), SNMP, deduplication/compression, Data Protection technologies, Snapshot technology, TCP/IP, and more. Ability to navigate through multiple software systems while troubleshooting with customers.
-
-                        </div>
-                        <div class="technologies-container">
-                            Tools / Technologies: <br>
-                            Customer environments were always specific to their needs. Technologies involved varied from issue to issue.
-                        </div>
-                    </div>
-                    -->
-                </div>
-                
-
-                <div class="work-experience-child-container">
-                    
-                    <div class="job-title-and-dates">
-                        <span class="job-title">USAF - Honorable Discharge</span><span class="dates">August 2001 - April 2005</span>
-                    </div>
-                </div>
-            </div>
+            <app-previous-experience></app-previous-experience>
+            
         </div>
     </div>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { ImageComponent } from './components/image/image.component';
 import { ContactComponent } from './components/contact/contact.component';
 import { EducationComponent } from './components/education/education.component';
 import { SitesComponent } from './components/sites/sites.component';
+import { PreviousExperienceComponent } from './components/previous-experience/previous-experience.component';
 
 @NgModule({
   declarations: [
@@ -20,7 +21,8 @@ import { SitesComponent } from './components/sites/sites.component';
     ImageComponent,
     ContactComponent,
     EducationComponent,
-    SitesComponent
+    SitesComponent,
+    PreviousExperienceComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/previous-experience/previous-experience.component.css
+++ b/src/app/components/previous-experience/previous-experience.component.css
@@ -1,0 +1,31 @@
+.previous-experience {
+    margin-top: 4%;
+}
+
+.previous-experience h4 {
+    margin-top: 0;
+    margin-bottom: 1%;
+    padding: 0;
+}
+
+.previous-experience-child-container {
+    padding-top: 0;
+    margin-bottom: 1%;
+    font-size: small;
+}
+
+.dates {
+    float: right;
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/app/components/previous-experience/previous-experience.component.html
+++ b/src/app/components/previous-experience/previous-experience.component.html
@@ -1,0 +1,17 @@
+<div class="previous-experience" *ngIf="previousExperience">
+    
+    <h4 class="header">Previous Experience</h4>
+
+    <div class="previous-experience-child-container" *ngFor="let item of previousExperience">
+
+        <div class="job-information">
+            <span class="job-title">{{item.jobTitle}}</span>
+            <span class="dates">{{item.startMonth}} {{item.startYear}} - {{item.endMonth}} {{item.endYear}}</span>
+        </div>
+
+        <div class="job-information">
+            <span class="job-title">{{item.companyName}}</span>
+            <span class="dates">{{item.city}}, {{item.state}}</span>
+        </div>
+    </div>
+</div>

--- a/src/app/components/previous-experience/previous-experience.component.spec.ts
+++ b/src/app/components/previous-experience/previous-experience.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PreviousExperienceComponent } from './previous-experience.component';
+import { PreviousExperienceService } from 'src/app/services/previous-experience.service';
+import { PREVIOUS_EXPERIENCE } from 'src/app/data/previous-experience';
+
+describe('PreviousExperienceComponent', () => {
+  let component: PreviousExperienceComponent;
+  let fixture: ComponentFixture<PreviousExperienceComponent>;
+  let previousExperienceService: PreviousExperienceService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PreviousExperienceComponent ],
+      providers: [ PreviousExperienceService ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PreviousExperienceComponent);
+    component = fixture.componentInstance;
+    previousExperienceService = TestBed.inject(PreviousExperienceService);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should retrieve previous work information from the service', () => {
+    spyOn(previousExperienceService, 'getPreviousExperience').and.returnValue(PREVIOUS_EXPERIENCE);
+    component.getPreviousWorkExperience();
+    expect(component.previousExperience).toEqual(PREVIOUS_EXPERIENCE);
+  });
+
+});

--- a/src/app/components/previous-experience/previous-experience.component.ts
+++ b/src/app/components/previous-experience/previous-experience.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { PreviousExperience } from 'src/app/models/previous-experience-model';
+import { PreviousExperienceService } from 'src/app/services/previous-experience.service';
+
+@Component({
+  selector: 'app-previous-experience',
+  templateUrl: './previous-experience.component.html',
+  styleUrls: ['./previous-experience.component.css']
+})
+export class PreviousExperienceComponent {
+  previousExperience!: PreviousExperience[];
+
+  ngOnInit(): void {
+    this.getPreviousWorkExperience();
+  }
+
+  constructor(
+    private previousExperienceService: PreviousExperienceService
+  ) {}
+
+  getPreviousWorkExperience(): void {
+    this.previousExperience = this.previousExperienceService.getPreviousExperience();
+  }
+}

--- a/src/app/data/previous-experience.ts
+++ b/src/app/data/previous-experience.ts
@@ -1,0 +1,38 @@
+import { PreviousExperience } from "../models/previous-experience-model";
+
+export const PREVIOUS_EXPERIENCE: PreviousExperience[] = [
+    {
+        id: 0,
+        jobTitle: 'System Administrator',
+        companyName: 'InFlyt Entertainment (Thales Avionics)',
+        startMonth: 'August',
+        startYear: '2017',
+        endMonth: 'July',
+        endYear: '2020',
+        city: 'Orlando',
+        state: 'FL'
+    },
+    {
+        id: 1,
+        jobTitle: 'Technical Support Engineer II',
+        companyName: 'Convergys: (NetApp Account)',
+        startMonth: 'August',
+        startYear: '2015',
+        endMonth: 'August',
+        endYear: '2017',
+        city: 'Lake Mary',
+        state: 'FL'
+    },
+    {
+        id: 2,
+        jobTitle: '',
+        companyName: 'USAF - Honorable Discharge',
+        startMonth: 'August',
+        startYear: '2001',
+        endMonth: 'April',
+        endYear: '2005',
+        city: '',
+        state: ''
+    },
+    
+]

--- a/src/app/models/previous-experience-model.ts
+++ b/src/app/models/previous-experience-model.ts
@@ -1,0 +1,11 @@
+export interface PreviousExperience {
+    id: number;
+    jobTitle: string;
+    companyName: string;
+    startMonth: string;
+    startYear: string;
+    endMonth: string;
+    endYear: string;
+    city: string;
+    state: string;
+}

--- a/src/app/services/previous-experience.service.spec.ts
+++ b/src/app/services/previous-experience.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PreviousExperienceService } from './previous-experience.service';
+
+describe('PreviousExperienceService', () => {
+  let service: PreviousExperienceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PreviousExperienceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/previous-experience.service.ts
+++ b/src/app/services/previous-experience.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+
+import { PreviousExperience } from '../models/previous-experience-model';
+import { PREVIOUS_EXPERIENCE } from '../data/previous-experience';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PreviousExperienceService {
+
+  constructor() { }
+
+  getPreviousExperience(): PreviousExperience[] {
+    return PREVIOUS_EXPERIENCE;
+  }
+}


### PR DESCRIPTION
Model: PreviousExperience
    id: number;
    jobTitle: string;
    companyName: string;
    startMonth: string;
    startYear: string;
    endMonth: string;
    endYear: string;
    city: string;
    state: string;

Data:
Utilized hard-coded data from main component HTML to build a PreviousExperience[]

Service:
getPreviousExperience method returns PreviousExperience[] object using mock-data

Component:
TS:
Added PreviousExperience[] previousExperience
Injected PreviousExperienceService into constructor
Created getPreviousWorkExperience function which assigns this.previousExperience the result of calling this.previousExperienceService.getPreviousExperience()
Added getPreviousWorkExperience function call to ngOnInit

HTML:
Removed relevant information from main component and replaced with <app-previous-experience> tag
Transferred relevant code to PreviousExperience component html 
Transitioned container div by utilitizing *ngIf to check for existence of previousExperience
Transitioned children by incorporating *ngFor and iterating through the array 
Replaced hard-coded data with string interpolation for associated model properties

CSS:
Transferred applicable stylings to component css
Verified consistency between previous version and print preview