### PR TITLE
user_0 Sites section rework

### DIFF
--- a/src/app/components/sites/sites.component.css
+++ b/src/app/components/sites/sites.component.css
@@ -10,12 +10,8 @@
     opacity: 25%;
 }
 
-.linkedin a {
-    font-size: x-small;
-}
-
 div a {
     text-decoration: none;
-    font-size: small;
+    font-size: x-small;
     color: black;
 }

--- a/src/app/components/sites/sites.component.html
+++ b/src/app/components/sites/sites.component.html
@@ -1,16 +1,10 @@
-<div class="sites-container">
+<div class="sites-container" *ngIf="sites">
     <h4>SITES</h4>
     <hr>
 
-    <div class="linkedin">
-        <a href={{sites.linkedin}}>
-            {{sites.linkedin}}
-        </a>
-    </div>
-
-    <div class="github">
-        <a href={{sites.github}}>
-            {{sites.github}}
+    <div class="site-link-container" *ngFor="let site of sites">
+        <a href={{site.site}}>
+            {{site.site}}
         </a>
     </div>
 </div>

--- a/src/app/components/sites/sites.component.ts
+++ b/src/app/components/sites/sites.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Sites } from 'src/app/models/sites-model';
+import { Site } from 'src/app/models/site-model';
 import { SitesService } from 'src/app/services/sites.service';
 
 @Component({
@@ -8,7 +8,7 @@ import { SitesService } from 'src/app/services/sites.service';
   styleUrls: ['./sites.component.css']
 })
 export class SitesComponent {
-  sites!: Sites;
+  sites!: Site[];
 
   ngOnInit(): void {
     this.getSites();

--- a/src/app/data/sites.ts
+++ b/src/app/data/sites.ts
@@ -1,7 +1,14 @@
-import { Sites } from "../models/sites-model";
+import { Site } from "../models/site-model";
 
-export const SITES: Sites = {
-    id: 0,
-    linkedin: "https://www.linkedin.com/in/zachary-miller-82179483/",
-    github: "https://github.com/zacharycmiller"
-}
+export const SITES: Site[] = [
+    {
+        id: 1,
+        resumeId: 999999,
+        site: "https://www.linkedin.com/in/zachary-miller-82179483/"
+    },
+    {
+        id: 2,
+        resumeId: 999999,
+        site: "https://github.com/zacharycmiller"
+    }
+]

--- a/src/app/models/site-model.ts
+++ b/src/app/models/site-model.ts
@@ -1,0 +1,5 @@
+export interface Site {
+    id: number;
+    resumeId: number;
+    site: string;
+}

--- a/src/app/models/sites-model.ts
+++ b/src/app/models/sites-model.ts
@@ -1,5 +1,0 @@
-export interface Sites {
-    id: number;
-    linkedin: string;
-    github: string;
-}

--- a/src/app/services/sites.service.ts
+++ b/src/app/services/sites.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { Sites } from '../models/sites-model';
+import { Site } from '../models/site-model';
 import { SITES } from '../data/sites';
 
 @Injectable({
@@ -10,7 +10,7 @@ export class SitesService {
 
   constructor() { }
 
-  getSites(): Sites {
+  getSites(): Site[] {
     return SITES;
   }
 }


### PR DESCRIPTION
To accommodate moving data to the backend, the model needed to shift to allow for database normalization. The following modifications were made:

Model:
Renamed from Sites to Site
Properties changed to id: number, resumeId: number, and site: string

Data:
Mock data was changed to return a Site[] and the two sites (linkedin and github) were given their own Site objects with resumeId 999999 (id being used for development) and site being the respective site string. 

Service:
getSites() function was modified to return a Site[]

Component:
TS:
sites property was changed to Site[]

HTML:
ngIf validation was added to outer container (checks for property sites)
ngFor loop was added to iterate over the Site objects 

CSS:
removed linkedin specific styling and modified div a to all use x-small font-size

Modified all references to Sites to Site

Visually validated that the sites appear and fit when selecting to print