### PR TITLE
Added editing capablitity to AboutMe

### DIFF
--- a/src/app/components/about-me/about-me.component.css
+++ b/src/app/components/about-me/about-me.component.css
@@ -1,3 +1,9 @@
+@media print {
+    button {
+        display: none;
+    }
+}
+
 .full-name-container {
     font-size: 32px;
     font-weight: bold;
@@ -12,4 +18,14 @@
 
 .introduction {
     font-size: small;
+}
+
+#introduction {
+    min-width: 99%;
+    max-width: 99%;
+}
+
+.edit-mode {
+    border: 1px solid black;
+    width: 100%;
 }

--- a/src/app/components/about-me/about-me.component.html
+++ b/src/app/components/about-me/about-me.component.html
@@ -1,6 +1,24 @@
-<div class="about-me-container" *ngIf=aboutMe>
-    <input class="full-name-container" [(ngModel)]="aboutMe.fullName" placeholder="Full Name">
-    
+<div class="about-me-container" *ngIf="aboutMe && mode === 'prod'">
+    <div class="full-name-container">{{aboutMe.fullName}}</div>
     <div class="job-title">{{aboutMe.jobTitle}}</div>
     <p class="introduction">{{aboutMe.introduction}}</p>
+    
+    <button (click)="changeMode()" *ngIf="mode === 'prod'">Edit</button>
 </div>
+
+<div class="edit-mode" *ngIf="mode === 'edit'">
+    <div> 
+        <input class="full-name-container" id="fullName" [(ngModel)]="aboutMe.fullName" placeholder="Full Name">
+    </div>
+    <div>
+        <input class="job-title" id="jobTitle" [(ngModel)]="aboutMe.jobTitle" placeholder="Job Title">
+    </div>
+    <div>
+        <textarea class="introduction" id="introduction" [(ngModel)]="aboutMe.introduction" placeholder="About Me"></textarea>
+    </div>
+
+    
+    <button (click)="save()" *ngIf="mode === 'edit'">Save</button>
+</div>
+
+

--- a/src/app/components/about-me/about-me.component.ts
+++ b/src/app/components/about-me/about-me.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Type } from '@angular/core';
 import { AboutMe } from '../../models/about-me-model';
 import { AboutMeService } from '../../services/about-me.service';
 
@@ -10,18 +10,32 @@ import { AboutMeService } from '../../services/about-me.service';
 
 export class AboutMeComponent {
   @Input() resumeId!: number;
+  mode: string = 'prod';
   aboutMe!: AboutMe;
 
   ngOnInit(): void {
-    this.getAboutMe(this.resumeId);
+    this.getAboutMeByResumeId(this.resumeId);
   }
 
   constructor(
     private aboutMeService: AboutMeService
   ) {}
 
-  getAboutMe(id: number): void {
-    this.aboutMeService.getAboutMeById(id)
-      .subscribe(aboutMe => this.aboutMe = aboutMe);
+  getAboutMeByResumeId(resumeId: number): void {
+    this.aboutMeService.getAboutMeByResumeId(resumeId).subscribe(aboutMe => {
+      this.aboutMe = aboutMe;
+      if( aboutMe.fullName === '' || aboutMe.jobTitle === '' || aboutMe.introduction === '') {
+        this.mode = 'edit';
+      }
+    });
+  }
+
+  save(): void {
+    this.aboutMeService.updateAboutMe(this.aboutMe).subscribe();
+    this.changeMode();
+  }
+
+  changeMode(): void {
+    this.mode = this.mode === 'prod' ? 'edit' : 'prod';
   }
 }

--- a/src/app/components/resume/resume.component.html
+++ b/src/app/components/resume/resume.component.html
@@ -1,7 +1,7 @@
 <div class="resume-container">
     
     <div class="left-side-container">
-        <app-about-me [id]=resumeId></app-about-me>
+        <app-about-me [resumeId]=resumeId></app-about-me>
         <!--<app-work-experience-tree [resumeId]=id></app-work-experience-tree>-->
         <app-work-experience [resumeId]=resumeId></app-work-experience>
         <app-previous-experience></app-previous-experience>

--- a/src/app/services/about-me.service.ts
+++ b/src/app/services/about-me.service.ts
@@ -13,19 +13,21 @@ export class AboutMeService {
   constructor(private http: HttpClient) { }
 
   // Method to get an AboutMe object by ID
-  getAboutMeById(id: number): Observable<AboutMe> {
-    const url = `${this.baseUrl}/1`;
+  getAboutMeByResumeId(id: number): Observable<AboutMe> {
+    const url = `${this.baseUrl}/${id}`;
     return this.http.get<AboutMe>(url);
   }
 
-  /*
-  * To be developed:
-  *
   // Method to update an existing AboutMe object
   updateAboutMe(aboutMe: AboutMe): Observable<any> {
     const url = `${this.baseUrl}/${aboutMe.id}`;
     return this.http.put(url, aboutMe);
   }
+
+  /*
+  * To be developed:
+  *
+  
 
   // Method to create a new AboutMe object
   createAboutMe(aboutMe: AboutMe): Observable<any> {


### PR DESCRIPTION
Created mode: string to set to 'prod'/'edit'
Created two-way binding to AboutMe properties for fullName, jobTitle, and aboutMeTextArea (introduction)
Once we receive the result of getAboutMeByResumeId, the 3 above properties are checked to see if they are blank
if any are, then mode is set to edit. Otherwise, mode is 'prod'
A person can currently save the AboutMe section with blank values to get to 'prod' mode
When the save button is pressed, it will call the updateAboutMe service method to save the new values and change the mode to 'prod'
If in prod mode and 'Edit' is clicked, it will switch the mode to 'edit'